### PR TITLE
fix - Players inventory was not being updated server side in creative when add item to hotbar

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1959,7 +1959,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					break;
 				}elseif($this->isCreative()){
 					$this->inventory->setHeldItemIndex($packet->selectedSlot);
-					//$this->inventory->setItem($packet->selectedSlot, $item);
+					$this->inventory->setItem($packet->selectedSlot, $item);
 					$this->inventory->setHeldItemSlot($packet->selectedSlot);
 				}else{
                     if($packet->selectedSlot >= 0 and $packet->selectedSlot < $this->inventory->getHotbarSize()){


### PR DESCRIPTION
When was this line commented out and why? Uncommenting it fixed the block placing problem while in creative. From the servers point of view players were attempting to place air