### PR TITLE
Creative Hotbar 'fix'

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -133,7 +133,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 				}elseif($item["Slot"] >= 100 and $item["Slot"] < 104){ //Armor
 					$this->inventory->setItem($this->inventory->getSize() + $item["Slot"] - 100, NBT::getItemHelper($item));
 				}else{
-					$this->inventory->setItem($item["Slot"] - 7, NBT::getItemHelper($item));
+					$this->inventory->setItem($item["Slot"] - 9, NBT::getItemHelper($item));
 				}
 			}
 		}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -128,7 +128,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		if(isset($this->namedtag->Inventory) and $this->namedtag->Inventory instanceof Enum){
 			foreach($this->namedtag->Inventory as $item){
-				if($item["Slot"] >= 0 and $item["Slot"] < 7){ //Hotbar
+				if($item["Slot"] >= 0 and $item["Slot"] < 9){ //Hotbar
 					$this->inventory->setHotbarSlotIndex($item["Slot"], isset($item["TrueSlot"]) ? $item["TrueSlot"] : -1);
 				}elseif($item["Slot"] >= 100 and $item["Slot"] < 104){ //Armor
 					$this->inventory->setItem($this->inventory->getSize() + $item["Slot"] - 100, NBT::getItemHelper($item));
@@ -184,10 +184,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 			}
 
 			//Normal inventory
-			$slotCount = Player::SURVIVAL_SLOTS + 7;
+			$slotCount = Player::SURVIVAL_SLOTS + 9;
 			//$slotCount = (($this instanceof Player and ($this->gamemode & 0x01) === 1) ? Player::CREATIVE_SLOTS : Player::SURVIVAL_SLOTS) + 9;
 			for($slot = 9; $slot < $slotCount; ++$slot){
-				$item = $this->inventory->getItem($slot - 7);
+				$item = $this->inventory->getItem($slot - 9);
 				$this->namedtag->Inventory[$slot] = NBT::putItemHelper($item, $slot);
 			}
 

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -386,6 +386,8 @@ class PlayerInventory extends BaseInventory{
 
 		$holder = $this->getHolder();
 		if($holder instanceof Player and $holder->isCreative()){
+			// mwvent - return because this packet causes problems - TODO: why?
+			return;
 			//TODO: Remove this workaround because of broken client
 			foreach(Item::getCreativeItems() as $i => $item){
 				$pk->slots[$i] = Item::getCreativeItem($i);

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -163,7 +163,7 @@ class PlayerInventory extends BaseInventory{
 	}
 
 	public function getHotbarSize(){
-		return 7;
+		return 9;
 	}
 
 	public function getArmorItem($index){


### PR DESCRIPTION
Submitting this PR with the disclaimer that I don't really understand why it works.

Effects of adding this PR should be
 - Stops hotbar bug - creative users don't get their hotbar blanked when switching slots
 - Prevents players getting blocked by Raklib when adding items to hotbar in creative (because the packets that is stopped causes and error)
 - Brings back the shovel bug occasionally - the lesser of the evils imho

I've tested this branch over and over with Win10 & Android but would love it if there was a few more people test before merging.

Shouldn't conflict with PR https://github.com/ImagicalCorp/PocketMine-0.13.0/pull/114 which was submitted just before I submitted this one but by all means merge that one first it has a lot more changes
  