### PR TITLE
Fix /setlang error for Vietnamese

### DIFF
--- a/src/pocketmine/lang/locale/vie.ini
+++ b/src/pocketmine/lang/locale/vie.ini
@@ -1,5 +1,5 @@
 
-language.name=Tiếng Việt
+language.name=Vietnamese
 language.selected=Chọn {%0} ({%1}) là ngôn ngữ chính
 
 multiplayer.player.joined={%0} tham gia trò chơi
@@ -162,7 +162,6 @@ pocketmine.server.defaultGameMode=Loại trò chơi mặc định: {%0}
 pocketmine.server.query.start=Chạy GS4 status listener
 pocketmine.server.query.info=Đặt cổng truy vấn là {%0}
 pocketmine.server.query.running=Địa chỉ truy vấn là {%0}:{%1}
-
 
 
 


### PR DESCRIPTION
When use /setlang, it's really important not to have a space in the language name. So by change it into "Vietnamese", /setlang will work with that :)